### PR TITLE
feature: Add AUR package instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,21 @@ I developed shhgit to raise awareness and bring to life the prevalence of this i
 
 ## Installation
 
-You can use the [precompiled binaries](https://www.github.com/eth0izzle/shhgit/releases) **or** build from source:
+### Prebuilt binaries
+
+**Note**: Doesn't require Go.
+
+You can use the [precompiled binaries](https://www.github.com/eth0izzle/shhgit/releases)
+
+### Arch Linux
+
+Install `shhgit` from the AUR.
+
+```bash
+yay -S shhgit
+```
+
+### Build from source
 
 1. Install [Go](https://golang.org/doc/install) for your platform.
 2. `$ go get github.com/eth0izzle/shhgit` will download and build shhgit.


### PR DESCRIPTION
1. Why is this change neccesary?
Because we needed to add instructions to install shhgit on Arch Linux hots.

2. How does it address the issue?
By adding the AUR instructions to get the PKGBUILD I created to the README.md.

3. What side effects does this change have?
None!

Here's the [AUR package](https://aur.archlinux.org/packages/shhgit/).

Screenshots:

![Screenshot_2019-09-24_19-01-04](https://user-images.githubusercontent.com/10160626/65558736-91758100-defd-11e9-813b-bc227fccc84c.png)
![Screenshot_2019-09-24_19-01-07](https://user-images.githubusercontent.com/10160626/65558856-df8a8480-defd-11e9-810e-a9a77f786c16.png)
![Screenshot_2019-09-24_19-01-16](https://user-images.githubusercontent.com/10160626/65558860-e31e0b80-defd-11e9-9973-aa9ba9af51dd.png)
