### PR TITLE
Organizations Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Alternatively, you can forgo the signatures and use shhgit with a search query, 
 ### Options
 
 ```
+--check-owner
+        Will check owner details before processing repo. Set to true to enable.
 --clone-repository-timeout
         Maximum time it should take to clone a repository in seconds (default 10)
 --csv-path
@@ -76,6 +78,7 @@ slack_webhook: '' # url to your slack webhook. Found secrets will be sent here
 blacklisted_extensions: [] # list of extensions to ignore
 blacklisted_paths: [] # list of paths to ignore
 blacklisted_entropy_extensions: [] # additional extensions to ignore for entropy checks
+organizations: []
 signatures: # list of signatures to check
   - part: '' # either filename, extension, path or contents
     match: '' # simple text comparison (if no regex element)

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,7 @@ slack_webhook: ''
 blacklisted_extensions: [".exe", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".psd", ".xcf", ".zip", ".tar.gz", ".ttf", ".lock"]
 blacklisted_paths: ["node_modules{sep}", "vendor{sep}bundle", "vendor{sep}cache"] # use {sep} for the OS' path seperator (i.e. / or \)
 blacklisted_entropy_extensions: [".pem", "id_rsa", ".asc", ".ovpn", ".sqlite", ".sqlite3"] # additional extensions to skip entropy checks
+organizations: []
 signatures:
   - part:  'extension'
     match: '.pem'

--- a/core/config.go
+++ b/core/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	BlacklistedPaths             []string          `yaml:"blacklisted_paths"`
 	BlacklistedEntropyExtensions []string          `yaml:"blacklisted_entropy_extensions"`
 	Signatures                   []ConfigSignature `yaml:"signatures"`
+	Organizations                []string          `yaml:"organizations`
 }
 
 type ConfigSignature struct {

--- a/core/github.go
+++ b/core/github.go
@@ -2,6 +2,10 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
 	"time"
 
 	"github.com/google/go-github/github"
@@ -147,4 +151,40 @@ func GetRepository(session *Session, id int64) (*github.Repository, error) {
 	}
 
 	return repo, nil
+}
+
+func GetUser(session *Session, id string) (*github.User, error) {
+	client := session.GetClient()
+	//println(id)
+	user, resp, err := client.Users.Get(session.Context, id)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Rate.Remaining <= 1 {
+		session.Log.Warn("Token %s[..] rate limited. Reset at %s", client.Token[:10], resp.Rate.Reset)
+		client.RateLimitedUntil = resp.Rate.Reset.Time
+	}
+
+	return user, nil
+}
+
+func GetGistOwner(gistUrl string) (string, error) {
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}}
+
+	resp, err := client.Get(gistUrl)
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer resp.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyString := string(bodyBytes)
+	r := regexp.MustCompile(`.com\/(.+)?\/.*.git`)
+	res := r.FindStringSubmatch(bodyString)
+	gistOwner := fmt.Sprint(res[1])
+	return gistOwner, nil
 }

--- a/core/github.go
+++ b/core/github.go
@@ -169,7 +169,7 @@ func GetUser(session *Session, id string) (*github.User, error) {
 
 	return user, nil
 }
-
+//The Google GitHub module didn't have support for this, so we have to make a web request and use some regex magic here.
 func GetGistOwner(gistUrl string) (string, error) {
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -185,6 +185,9 @@ func GetGistOwner(gistUrl string) (string, error) {
 	bodyString := string(bodyBytes)
 	r := regexp.MustCompile(`.com\/(.+)?\/.*.git`)
 	res := r.FindStringSubmatch(bodyString)
-	gistOwner := fmt.Sprint(res[1])
-	return gistOwner, nil
+	if len(res) != 0 {
+		gistOwner := fmt.Sprint(res[1])
+		return gistOwner, nil
+	}
+	return "err_getting_user", err
 }

--- a/core/match.go
+++ b/core/match.go
@@ -75,3 +75,13 @@ func GetMatchingFiles(dir string) []MatchFile {
 
 	return fileList
 }
+
+func IsMember(name string) bool {
+	for _, organization := range session.Config.Organizations {
+		if strings.Contains(strings.ToLower(name), strings.ToLower(organization)) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/core/options.go
+++ b/core/options.go
@@ -20,6 +20,7 @@ type Options struct {
 	TempDirectory          *string
 	CsvPath                *string
 	SearchQuery            *string
+	CheckOwner             *bool
 }
 
 func ParseOptions() (*Options, error) {
@@ -34,6 +35,7 @@ func ParseOptions() (*Options, error) {
 		MinimumStars:           flag.Uint("minimum-stars", 0, "Only process repositories with this many stars. Default 0 will ignore star count"),
 		PathChecks:             flag.Bool("path-checks", true, "Set to false to disable checking of filepaths, i.e. just match regex patterns of file contents"),
 		ProcessGists:           flag.Bool("process-gists", true, "Will watch and process Gists. Set to false to disable."),
+		CheckOwner:             flag.Bool("check-owner", false, "Will check owner details before processing repo. Set to true to enable."),
 		TempDirectory:          flag.String("temp-directory", filepath.Join(os.TempDir(), Name), "Directory to process and store repositories/matches"),
 		CsvPath:                flag.String("csv-path", "", "CSV file path to log found secrets to. Leave blank to disable"),
 		SearchQuery:            flag.String("search-query", "", "Specify a search string to ignore signatures and filter on files containing this string (regex compatible)"),

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jordanpotti/shhgit
+module github.com/eth0izzle/shhgit
 
 go 1.12.9
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/eth0izzle/shhgit
+module github.com/jordanpotti/shhgit
 
 go 1.12.9
 

--- a/main.go
+++ b/main.go
@@ -33,12 +33,11 @@ func CheckOwnerGist(gistUrl string) bool {
 	gistOwner, err := core.GetGistOwner(gistUrl)
 	owner, err := core.GetUser(session, gistOwner)
 	ownerDetails := []string{owner.GetCompany(), owner.GetEmail(), owner.GetBlog(), owner.GetLogin(), owner.GetBio()}
-	if err != nil {
-		session.Log.Warn("Failed to retrieve owner details %d: %s", gistOwner, err)
+	if err != nil || gistOwner == "err_getting_user" {
+		//session.Log.Warn("Failed to retrieve owner details %d: %s", gistOwner, err)
 		return false
 	}
 	ownerString := strings.Join(ownerDetails, " ")
-	//print(ownerString)
 	if !core.IsMember(ownerString) {
 		return false
 	}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/eth0izzle/shhgit/core"
+	"github.com/jordanpotti/shhgit/core"
 	"github.com/fatih/color"
 	"github.com/google/go-github/github"
 )

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/jordanpotti/shhgit/core"
+	"github.com/eth0izzle/shhgit/core"
 	"github.com/fatih/color"
 	"github.com/google/go-github/github"
 )


### PR DESCRIPTION
Feature addition that allows a list of organizations to be added, the shhgit tool will then only process repos and gists that are owned by members of certain organizations. 

The match looks at the users email, bio, username and company to match on a list of given strings specified in the config file. 