### PR TITLE
Remove unused global variable baseUrl

### DIFF
--- a/core/github.go
+++ b/core/github.go
@@ -14,7 +14,6 @@ type GitHubClientWrapper struct {
 }
 
 const (
-	baseUrl = "https://www.github.com"
 	perPage = 300
 	sleep   = 30 * time.Second
 )


### PR DESCRIPTION
Seems to be obsolete by now.