### PR TITLE
Avoid unnecessary conversions

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -36,7 +36,7 @@ func ParseConfig() (*Config, error) {
 		return config, err
 	}
 
-	err = yaml.Unmarshal([]byte(data), config)
+	err = yaml.Unmarshal(data, config)
 	if err != nil {
 		return config, err
 	}

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func processRepositoryOrGist(url string) {
 		matchedAny bool = false
 	)
 
-	dir := core.GetTempDir(core.GetHash(string(url)))
+	dir := core.GetTempDir(core.GetHash(url))
 	_, err := core.CloneRepository(session, url, dir)
 
 	if err != nil {


### PR DESCRIPTION
No need to convert these types, they already match.