### PR TITLE
Add token from env

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"fmt"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -42,11 +41,9 @@ func ParseConfig() (*Config, error) {
 		return config, err
 	}
 
-	tokens := config.GitHubAccessTokens[:0]
-	for index, token := range config.GitHubAccessTokens {
-		tokens = append(tokens, os.ExpandEnv(token))
+	for i := 0; i < len(config.GitHubAccessTokens); i++ {
+		config.GitHubAccessTokens[i] = os.ExpandEnv(config.GitHubAccessTokens[i])
 	}
-	config.GitHubAccessTokens = tokens
 
 	if len(config.SlackWebhook) > 0 {
 		config.SlackWebhook = os.ExpandEnv(config.SlackWebhook)

--- a/core/config.go
+++ b/core/config.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"fmt"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -36,11 +37,19 @@ func ParseConfig() (*Config, error) {
 		return config, err
 	}
 
-	subst := []byte(os.ExpandEnv(string(data)))
-
-	err = yaml.Unmarshal(subst, config)
+	err = yaml.Unmarshal(data, config)
 	if err != nil {
 		return config, err
+	}
+
+	tokens := config.GitHubAccessTokens[:0]
+	for index, token := range config.GitHubAccessTokens {
+		tokens = append(tokens, os.ExpandEnv(token))
+	}
+	config.GitHubAccessTokens = tokens
+
+	if len(config.SlackWebhook) > 0 {
+		config.SlackWebhook = os.ExpandEnv(config.SlackWebhook)
 	}
 
 	return config, nil

--- a/core/config.go
+++ b/core/config.go
@@ -36,7 +36,9 @@ func ParseConfig() (*Config, error) {
 		return config, err
 	}
 
-	err = yaml.Unmarshal(data, config)
+	subst := []byte(os.ExpandEnv(string(data)))
+
+	err = yaml.Unmarshal(subst, config)
 	if err != nil {
 		return config, err
 	}


### PR DESCRIPTION
you can specify `${VARIABLE}` or `$VARIABLE` to use substitute environment variables

slack url and github tokens can be substituted

actually relates with #26 
here is example:

`docker run --rm -it -e GITHUB_TOKEN=your_token_here eth0izzle/shhgit`