### PR TITLE
Config Yaml file into container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 Dockerfile
 LICENSE
 README.md
-config.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS builder
+FROM docker.artifactory.michelin.com/golang:alpine AS builder
 
 WORKDIR /go/src
 ADD . .
@@ -10,5 +10,6 @@ VOLUME /tmp/shhgit
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /shhgit .
+ADD config.yaml .
 
 ENTRYPOINT [ "/shhgit" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.artifactory.michelin.com/golang:alpine AS builder
+FROM golang:alpine AS builder
 
 WORKDIR /go/src
 ADD . .
@@ -10,6 +10,6 @@ VOLUME /tmp/shhgit
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /shhgit .
-ADD config.yaml .
+COPY config.yaml .
 
 ENTRYPOINT [ "/shhgit" ]


### PR DESCRIPTION
The goal was to simplify the usage and build of a Dockerised shhgit image.
The workflow is now simpler :
- The user git clone
- The user modify his config.yaml (if not for local repository)
- The user build the image with the config.yaml file within it