### PR TITLE
Added a feature to mark/whitelist lines containing false positives

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ webhook_payload: |
     "text": "%s"
   }
 
+ignore_line_pragmas: ["THIS_IS_NOT_A_SECRET"] # Skip entire line if it contains this pragma
 blacklisted_strings: ["AKIAIOSFODNN7EXAMPLE", "username:password", "sshpass -p $SSH_PASS"] # skip matches containing any of these strings (case insensitive
 blacklisted_extensions: [".exe", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".psd", ".xcf", ".zip", ".tar.gz", ".ttf", ".lock"]
 blacklisted_paths: ["node_modules{sep}", "vendor{sep}bundle", "vendor{sep}cache"] # use {sep} for the OS' path seperator (i.e. / or \)

--- a/core/config.go
+++ b/core/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	GitHubAccessTokens           []string          `yaml:"github_access_tokens"`
 	Webhook                      string            `yaml:"webhook,omitempty"`
 	WebhookPayload               string            `yaml:"webhook_payload,omitempty"`
+	IgnoreLinePragmas            []string          `yaml:"ignore_line_pragmas"`
 	BlacklistedStrings           []string          `yaml:"blacklisted_strings"`
 	BlacklistedExtensions        []string          `yaml:"blacklisted_extensions"`
 	BlacklistedPaths             []string          `yaml:"blacklisted_paths"`

--- a/core/signatures_test.go
+++ b/core/signatures_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStripIgnoredLinesMultiLineWithoutPragma(t *testing.T) {
+	multiLineString := `line1
+	line2
+	line3`
+	multiLineByteArray := []byte(multiLineString)
+	assert.Equal(t, StripIgnoredLines(multiLineByteArray, []string{"PRAGMA"}), multiLineByteArray)
+}
+
+func TestStripIgnoredLinesMultiLineWithPragma(t *testing.T) {
+	multiLineString := `line1
+	line2 #PRAGMA
+	line3`
+	multiLineByteArray := []byte(multiLineString)
+
+	expectedString := `line1
+	line3`
+	expectedByteArray := []byte(expectedString)
+
+	assert.Equal(t, StripIgnoredLines(multiLineByteArray, []string{"PRAGMA"}), expectedByteArray)
+}
+
+func TestStripIgnoredLinesSingleLineWithoutPragma(t *testing.T) {
+	multiLineString := `line1`
+	multiLineByteArray := []byte(multiLineString)
+
+	assert.Equal(t, StripIgnoredLines(multiLineByteArray, []string{"PRAGMA"}), multiLineByteArray)
+}
+
+func TestStripIgnoredLinesSingleLineWithPragma(t *testing.T) {
+	multiLineString := `line1 #PRAGMA`
+	multiLineByteArray := []byte(multiLineString)
+	assert.Equal(t, StripIgnoredLines(multiLineByteArray, []string{"PRAGMA"}), []byte{})
+}
+
+func TestStripIgnoredLinesEmptyText(t *testing.T) {
+	multiLineString := ``
+	multiLineByteArray := []byte(multiLineString)
+	assert.Equal(t, StripIgnoredLines(multiLineByteArray, []string{"PRAGMA"}), []byte(nil))
+}
+
+func TestStripIgnoredLinesMultiLineWithMultiPragma(t *testing.T) {
+	multiLineString := `line1 #PRAGMA
+line2
+line3 #PRAGMA`
+	multiLineByteArray := []byte(multiLineString)
+
+	expectedString := `line2`
+	expectedByteArray := []byte(expectedString)
+
+	assert.Equal(t, StripIgnoredLines(multiLineByteArray, []string{"PRAGMA"}), expectedByteArray)
+}
+
+func TestStripIgnoredLinesMultiLineWithMultiPragmas(t *testing.T) {
+	multiLineString := `line1 #PRAGMA
+line2
+line3 #AMGARP`
+	multiLineByteArray := []byte(multiLineString)
+
+	expectedString := `line2`
+	expectedByteArray := []byte(expectedString)
+
+	assert.Equal(t, StripIgnoredLines(multiLineByteArray, []string{"PRAGMA", "AMGARP"}), expectedByteArray)
+}


### PR DESCRIPTION
Added a configurable field which allows defining one or many markers so developers can add in their code as in-line comments to whitelist false positives detected by shhgit. 
We found this pretty handy to get cleaner results without having to blacklist secrets one by one in the config.yaml file.

