### PR TITLE
Fixed matching file path in csv export report for windows platform

### DIFF
--- a/core/match.go
+++ b/core/match.go
@@ -15,7 +15,6 @@ type MatchFile struct {
 }
 
 func NewMatchFile(path string) MatchFile {
-	path = filepath.ToSlash(path)
 	_, filename := filepath.Split(path)
 	extension := filepath.Ext(path)
 	contents, _ := ioutil.ReadFile(path)


### PR DESCRIPTION
While exporting the csv scan report, the path of the matching file was showing full path separated by '/' in windows platform which in actual case should show only relative file path separated by '/'.This bug was fixed by removing path = filepath.ToSlash(path) inside NewMatchFile function in core/match.go file.