### PR TITLE
Remove globals from core to improve usage as a library

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -38,7 +38,7 @@ func ParseConfig(options *Options) (*Config, error) {
 	)
 
 	if len(*options.ConfigPath) > 0 {
-		data, err = ioutil.ReadFile(path.Join(*options.ConfigPath, "config.yaml"))
+		data, err = ioutil.ReadFile(path.Join(*options.ConfigPath, *options.ConfigName))
 		if err != nil {
 			return config, err
 		}
@@ -47,10 +47,10 @@ func ParseConfig(options *Options) (*Config, error) {
 		// Helps e.g. with Drone where workdir is different than shhgit dir
 		ex, err := os.Executable()
 		dir := filepath.Dir(ex)
-		data, err = ioutil.ReadFile(path.Join(dir, "config.yaml"))
+		data, err = ioutil.ReadFile(path.Join(dir, *options.ConfigName))
 		if err != nil {
 			dir, _ = os.Getwd()
-			data, err = ioutil.ReadFile(path.Join(dir, "config.yaml"))
+			data, err = ioutil.ReadFile(path.Join(dir, *options.ConfigName))
 			if err != nil {
 				return config, err
 			}

--- a/core/log.go
+++ b/core/log.go
@@ -30,6 +30,7 @@ var LogColors = map[int]*color.Color{
 
 type Logger struct {
 	sync.Mutex
+	s *Session
 
 	debug  bool
 	silent bool
@@ -61,10 +62,10 @@ func (l *Logger) Log(level int, format string, args ...interface{}) {
 		fmt.Printf("\r"+format+"\n", args...)
 	}
 
-	if level > WARN && session.Config.Webhook != "" {
+	if level > WARN && l.s.Config.Webhook != "" {
 		text := colorStrip(fmt.Sprintf(format, args...))
-		payload := fmt.Sprintf(session.Config.WebhookPayload, text)
-		http.Post(session.Config.Webhook, "application/json", strings.NewReader(payload))
+		payload := fmt.Sprintf(l.s.Config.WebhookPayload, text)
+		http.Post(l.s.Config.Webhook, "application/json", strings.NewReader(payload))
 	}
 
 	if level == FATAL {

--- a/core/match.go
+++ b/core/match.go
@@ -28,16 +28,16 @@ func NewMatchFile(path string) MatchFile {
 	}
 }
 
-func IsSkippableFile(path string) bool {
+func IsSkippableFile(s *Session, path string) bool {
 	extension := strings.ToLower(filepath.Ext(path))
 
-	for _, skippableExt := range session.Config.BlacklistedExtensions {
+	for _, skippableExt := range s.Config.BlacklistedExtensions {
 		if extension == skippableExt {
 			return true
 		}
 	}
 
-	for _, skippablePathIndicator := range session.Config.BlacklistedPaths {
+	for _, skippablePathIndicator := range s.Config.BlacklistedPaths {
 		skippablePathIndicator = strings.Replace(skippablePathIndicator, "{sep}", string(os.PathSeparator), -1)
 		if strings.Contains(path, skippablePathIndicator) {
 			return true
@@ -47,12 +47,12 @@ func IsSkippableFile(path string) bool {
 	return false
 }
 
-func (match MatchFile) CanCheckEntropy() bool {
+func (match MatchFile) CanCheckEntropy(s *Session) bool {
 	if match.Filename == "id_rsa" {
 		return false
 	}
 
-	for _, skippableExt := range session.Config.BlacklistedEntropyExtensions {
+	for _, skippableExt := range s.Config.BlacklistedEntropyExtensions {
 		if match.Extension == skippableExt {
 			return false
 		}
@@ -61,12 +61,12 @@ func (match MatchFile) CanCheckEntropy() bool {
 	return true
 }
 
-func GetMatchingFiles(dir string) []MatchFile {
+func GetMatchingFiles(s *Session, dir string) []MatchFile {
 	fileList := make([]MatchFile, 0)
-	maxFileSize := *session.Options.MaximumFileSize * 1024
+	maxFileSize := *s.Options.MaximumFileSize * 1024
 
 	filepath.Walk(dir, func(path string, f os.FileInfo, err error) error {
-		if err != nil || f.IsDir() || uint(f.Size()) > maxFileSize || IsSkippableFile(path) {
+		if err != nil || f.IsDir() || uint(f.Size()) > maxFileSize || IsSkippableFile(s, path) {
 			return nil
 		}
 		fileList = append(fileList, NewMatchFile(path))

--- a/core/options.go
+++ b/core/options.go
@@ -1,11 +1,5 @@
 package core
 
-import (
-	"flag"
-	"os"
-	"path/filepath"
-)
-
 type Options struct {
 	Threads                *int
 	Silent                 *bool
@@ -78,34 +72,23 @@ func (o *Options) Merge(new *Options) {
 	if new.ConfigName != nil {
 		o.ConfigName = new.ConfigName
 	}
-
 }
 
-func ParseOptions() (*Options, error) {
-	options := &Options{
-		Threads:                flag.Int("threads", 0, "Number of concurrent threads (default number of logical CPUs)"),
-		Silent:                 flag.Bool("silent", false, "Suppress all output except for errors"),
-		Debug:                  flag.Bool("debug", false, "Print debugging information"),
-		MaximumRepositorySize:  flag.Uint("maximum-repository-size", 5120, "Maximum repository size to process in KB"),
-		MaximumFileSize:        flag.Uint("maximum-file-size", 256, "Maximum file size to process in KB"),
-		CloneRepositoryTimeout: flag.Uint("clone-repository-timeout", 10, "Maximum time it should take to clone a repository in seconds. Increase this if you have a slower connection"),
-		EntropyThreshold:       flag.Float64("entropy-threshold", 5.0, "Set to 0 to disable entropy checks"),
-		MinimumStars:           flag.Uint("minimum-stars", 0, "Only process repositories with this many stars. Default 0 will ignore star count"),
-		PathChecks:             flag.Bool("path-checks", true, "Set to false to disable checking of filepaths, i.e. just match regex patterns of file contents"),
-		ProcessGists:           flag.Bool("process-gists", true, "Will watch and process Gists. Set to false to disable."),
-		TempDirectory:          flag.String("temp-directory", filepath.Join(os.TempDir(), Name), "Directory to process and store repositories/matches"),
-		CsvPath:                flag.String("csv-path", "", "CSV file path to log found secrets to. Leave blank to disable"),
-		SearchQuery:            flag.String("search-query", "", "Specify a search string to ignore signatures and filter on files containing this string (regex compatible)"),
-		Local:                  flag.String("local", "", "Specify local directory (absolute path) which to scan. Scans only given directory recursively. No need to have GitHub tokens with local run."),
-		Live:                   flag.String("live", "", "Your shhgit live endpoint"),
-		ConfigPath:             flag.String("config-path", "", "Searches for config.yaml from given directory. If not set, tries to find if from shhgit binary's and current directory"),
+var (
+	// Defaults that don't represent Go struct defaults
+	DefaultMaximumRepositorySize  = uint(5120)
+	DefaultMaximumFileSize        = uint(256)
+	DefaultCloneRepositoryTimeout = uint(10)
+	DefaultEntropy                = float64(5.0)
+	DefaultPathChecks             = true
+	DefaultProcessGists           = true
+
+	DefaultOptions = Options{
+		MaximumRepositorySize:  &DefaultMaximumRepositorySize,
+		MaximumFileSize:        &DefaultMaximumFileSize,
+		CloneRepositoryTimeout: &DefaultCloneRepositoryTimeout,
+		EntropyThreshold:       &DefaultEntropy,
+		PathChecks:             &DefaultPathChecks,
+		ProcessGists:           &DefaultProcessGists,
 	}
-
-	// Undocumented option
-	configName := "config.yaml"
-	options.ConfigName = &configName
-
-	flag.Parse()
-
-	return options, nil
-}
+)

--- a/core/options.go
+++ b/core/options.go
@@ -1,5 +1,10 @@
 package core
 
+import (
+	"os"
+	"path/filepath"
+)
+
 type Options struct {
 	Threads                *int
 	Silent                 *bool
@@ -12,7 +17,7 @@ type Options struct {
 	PathChecks             *bool
 	ProcessGists           *bool
 	TempDirectory          *string
-	CsvPath                *string
+	CSVPath                *string
 	SearchQuery            *string
 	Local                  *string
 	Live                   *string
@@ -54,8 +59,8 @@ func (o *Options) Merge(new *Options) {
 	if new.TempDirectory != nil {
 		o.TempDirectory = new.TempDirectory
 	}
-	if new.CsvPath != nil {
-		o.CsvPath = new.CsvPath
+	if new.CSVPath != nil {
+		o.CSVPath = new.CSVPath
 	}
 	if new.SearchQuery != nil {
 		o.SearchQuery = new.SearchQuery
@@ -82,6 +87,12 @@ var (
 	DefaultEntropy                = float64(5.0)
 	DefaultPathChecks             = true
 	DefaultProcessGists           = true
+	DefaultSilent                 = false
+	DefaultMinimumStars           = uint(0)
+	DefaultDebug                  = false
+	DefaultTempDirectory          = filepath.Join(os.TempDir(), Name)
+	DefaultThreads                = 0
+	DefaultCSVPath                = ""
 
 	DefaultOptions = Options{
 		MaximumRepositorySize:  &DefaultMaximumRepositorySize,
@@ -90,5 +101,11 @@ var (
 		EntropyThreshold:       &DefaultEntropy,
 		PathChecks:             &DefaultPathChecks,
 		ProcessGists:           &DefaultProcessGists,
+		TempDirectory:          &DefaultTempDirectory,
+		Silent:                 &DefaultSilent,
+		Debug:                  &DefaultDebug,
+		Threads:                &DefaultThreads,
+		MinimumStars:           &DefaultMinimumStars,
+		CSVPath:                &DefaultCSVPath,
 	}
 )

--- a/core/options.go
+++ b/core/options.go
@@ -23,6 +23,62 @@ type Options struct {
 	Local                  *string
 	Live                   *string
 	ConfigPath             *string
+	ConfigName             *string
+}
+
+func (o *Options) Merge(new *Options) {
+	if new.Threads != nil {
+		o.Threads = new.Threads
+	}
+	if new.Silent != nil {
+		o.Silent = new.Silent
+	}
+	if new.Debug != nil {
+		o.Debug = new.Debug
+	}
+	if new.MaximumRepositorySize != nil {
+		o.MaximumRepositorySize = new.MaximumRepositorySize
+	}
+	if new.MaximumFileSize != nil {
+		o.MaximumFileSize = new.MaximumFileSize
+	}
+	if new.CloneRepositoryTimeout != nil {
+		o.CloneRepositoryTimeout = new.CloneRepositoryTimeout
+	}
+	if new.EntropyThreshold != nil {
+		o.EntropyThreshold = new.EntropyThreshold
+	}
+	if new.MinimumStars != nil {
+		o.MinimumStars = new.MinimumStars
+	}
+	if new.PathChecks != nil {
+		o.PathChecks = new.PathChecks
+	}
+	if new.ProcessGists != nil {
+		o.ProcessGists = new.ProcessGists
+	}
+	if new.TempDirectory != nil {
+		o.TempDirectory = new.TempDirectory
+	}
+	if new.CsvPath != nil {
+		o.CsvPath = new.CsvPath
+	}
+	if new.SearchQuery != nil {
+		o.SearchQuery = new.SearchQuery
+	}
+	if new.Local != nil {
+		o.Local = new.Local
+	}
+	if new.Live != nil {
+		o.Live = new.Live
+	}
+	if new.ConfigPath != nil {
+		o.ConfigPath = new.ConfigPath
+	}
+	if new.ConfigName != nil {
+		o.ConfigName = new.ConfigName
+	}
+
 }
 
 func ParseOptions() (*Options, error) {
@@ -44,6 +100,10 @@ func ParseOptions() (*Options, error) {
 		Live:                   flag.String("live", "", "Your shhgit live endpoint"),
 		ConfigPath:             flag.String("config-path", "", "Searches for config.yaml from given directory. If not set, tries to find if from shhgit binary's and current directory"),
 	}
+
+	// Undocumented option
+	configName := "config.yaml"
+	options.ConfigName = &configName
 
 	flag.Parse()
 

--- a/core/session.go
+++ b/core/session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/csv"
 	"fmt"
-	"log"
 	"math/rand"
 	"os"
 	"runtime"
@@ -126,16 +125,16 @@ func (s *Session) InitThreads() {
 }
 
 func (s *Session) InitCsvWriter() {
-	if *s.Options.CsvPath == "" {
+	if *s.Options.CSVPath == "" {
 		return
 	}
 
 	writeHeader := false
-	if !PathExists(*s.Options.CsvPath) {
+	if !PathExists(*s.Options.CSVPath) {
 		writeHeader = true
 	}
 
-	file, err := os.OpenFile(*s.Options.CsvPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(*s.Options.CSVPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		s.Log.Error("Could not create/open CSV file: %v", err)
 	}
@@ -148,7 +147,7 @@ func (s *Session) InitCsvWriter() {
 }
 
 func (s *Session) WriteToCsv(line []string) {
-	if *s.Options.CsvPath == "" {
+	if *s.Options.CSVPath == "" {
 		return
 	}
 
@@ -167,8 +166,6 @@ func NewSession(ctx context.Context, o *Options) (*Session, error) {
 	}
 
 	s.Options.Merge(o)
-	log.Printf("options: %s", *s.Options.ConfigName)
-
 	sc, err := ParseConfig(s.Options)
 	if err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)

--- a/core/signatures.go
+++ b/core/signatures.go
@@ -20,6 +20,7 @@ type Signature interface {
 	Name() string
 	Match(MatchFile) (bool, string)
 	GetContentsMatches(*Session, []byte) []string
+	StringSubMatches(*Session, []byte) [][]string
 }
 
 type SimpleSignature struct {
@@ -61,6 +62,10 @@ func (s SimpleSignature) GetContentsMatches(sess *Session, contents []byte) []st
 	return nil
 }
 
+func (s SimpleSignature) StringSubMatches(sess *Session, contents []byte) [][]string {
+	return nil
+}
+
 func (s SimpleSignature) Name() string {
 	return s.name
 }
@@ -99,6 +104,27 @@ func (s PatternSignature) GetContentsMatches(sess *Session, contents []byte) []s
 
 		for _, blacklistedString := range sess.Config.BlacklistedStrings {
 			if strings.Contains(strings.ToLower(match), strings.ToLower(blacklistedString)) {
+				blacklistedMatch = true
+			}
+		}
+
+		if !blacklistedMatch {
+			matches = append(matches, match)
+		}
+	}
+
+	return matches
+}
+
+func (s PatternSignature) StringSubMatches(sess *Session, contents []byte) [][]string {
+	matches := [][]string{}
+
+	for _, match := range s.match.FindAllStringSubmatch(string(contents), -1) {
+		fullMatch := string(match[0])
+		blacklistedMatch := false
+
+		for _, blacklistedString := range sess.Config.BlacklistedStrings {
+			if strings.Contains(strings.ToLower(fullMatch), strings.ToLower(blacklistedString)) {
 				blacklistedMatch = true
 			}
 		}

--- a/core/signatures.go
+++ b/core/signatures.go
@@ -18,8 +18,8 @@ const (
 
 type Signature interface {
 	Name() string
-	Match(file MatchFile) (bool, string)
-	GetContentsMatches(contents []byte) []string
+	Match(MatchFile) (bool, string)
+	GetContentsMatches(*Session, []byte) []string
 }
 
 type SimpleSignature struct {
@@ -57,7 +57,7 @@ func (s SimpleSignature) Match(file MatchFile) (bool, string) {
 	return (s.match == *haystack), matchPart
 }
 
-func (s SimpleSignature) GetContentsMatches(contents []byte) []string {
+func (s SimpleSignature) GetContentsMatches(sess *Session, contents []byte) []string {
 	return nil
 }
 
@@ -90,14 +90,14 @@ func (s PatternSignature) Match(file MatchFile) (bool, string) {
 	return s.match.MatchString(*haystack), matchPart
 }
 
-func (s PatternSignature) GetContentsMatches(contents []byte) []string {
+func (s PatternSignature) GetContentsMatches(sess *Session, contents []byte) []string {
 	matches := make([]string, 0)
 
 	for _, match := range s.match.FindAllSubmatch(contents, -1) {
 		match := string(match[0])
 		blacklistedMatch := false
 
-		for _, blacklistedString := range session.Config.BlacklistedStrings {
+		for _, blacklistedString := range sess.Config.BlacklistedStrings {
 			if strings.Contains(strings.ToLower(match), strings.ToLower(blacklistedString)) {
 				blacklistedMatch = true
 			}

--- a/core/util.go
+++ b/core/util.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 )
 
-func GetTempDir(suffix string) string {
-	dir := filepath.Join(*session.Options.TempDirectory, suffix)
+func GetTempDir(s *Session, suffix string) string {
+	dir := filepath.Join(*s.Options.TempDirectory, suffix)
 
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		os.MkdirAll(dir, os.ModePerm)
@@ -32,12 +32,6 @@ func PathExists(path string) bool {
 	}
 
 	return false
-}
-
-func LogIfError(text string, err error) {
-	if err != nil {
-		GetSession().Log.Error("%s (%s", text, err.Error())
-	}
 }
 
 func GetHash(s string) string {

--- a/main.go
+++ b/main.go
@@ -19,17 +19,17 @@ import (
 )
 
 var (
-	threadsFlag      = flag.Int("threads", 0, "Number of concurrent threads (default number of logical CPUs)")
-	silentFlag       = flag.Bool("silent", false, "Suppress all output except for errors")
-	debugFlag        = flag.Bool("debug", false, "Print debugging information")
-	maxRepoFlag      = flag.Uint("maximum-repository-size", 5120, "Maximum repository size to process in KB")
-	maxFileSizeFlag  = flag.Uint("maximum-file-size", 256, "Maximum file size to process in KB")
-	cloneTimeoutFlag = flag.Uint("clone-repository-timeout", 10, "Maximum time it should take to clone a repository in seconds. Increase this if you have a slower connection")
-	entropyFlag      = flag.Float64("entropy-threshold", 5.0, "Set to 0 to disable entropy checks")
-	minStarsFlag     = flag.Uint("minimum-stars", 0, "Only process repositories with this many stars. Default 0 will ignore star count")
-	pathChecksFlag   = flag.Bool("path-checks", true, "Set to false to disable checking of filepaths, i.e. just match regex patterns of file contents")
-	gistsFlag        = flag.Bool("process-gists", true, "Will watch and process Gists. Set to false to disable.")
-	tempDirFlag      = flag.String("temp-directory", filepath.Join(os.TempDir(), core.Name), "Directory to process and store repositories/matches")
+	threadsFlag      = flag.Int("threads", core.DefaultThreads, "Number of concurrent threads (default number of logical CPUs)")
+	silentFlag       = flag.Bool("silent", core.DefaultSilent, "Suppress all output except for errors")
+	debugFlag        = flag.Bool("debug", core.DefaultDebug, "Print debugging information")
+	maxRepoFlag      = flag.Uint("maximum-repository-size", core.DefaultMaximumRepositorySize, "Maximum repository size to process in KB")
+	maxFileSizeFlag  = flag.Uint("maximum-file-size", core.DefaultMaximumFileSize, "Maximum file size to process in KB")
+	cloneTimeoutFlag = flag.Uint("clone-repository-timeout", core.DefaultCloneRepositoryTimeout, "Maximum time it should take to clone a repository in seconds. Increase this if you have a slower connection")
+	entropyFlag      = flag.Float64("entropy-threshold", core.DefaultEntropy, "Set to 0 to disable entropy checks")
+	minStarsFlag     = flag.Uint("minimum-stars", core.DefaultMinimumStars, "Only process repositories with this many stars. Default 0 will ignore star count")
+	pathChecksFlag   = flag.Bool("path-checks", core.DefaultPathChecks, "Set to false to disable checking of filepaths, i.e. just match regex patterns of file contents")
+	gistsFlag        = flag.Bool("process-gists", core.DefaultProcessGists, "Will watch and process Gists. Set to false to disable.")
+	tempDirFlag      = flag.String("temp-directory", core.DefaultTempDirectory, "Directory to process and store repositories/matches")
 	csvFlag          = flag.String("csv-path", "", "CSV file path to log found secrets to. Leave blank to disable")
 	searchQueryFlag  = flag.String("search-query", "", "Specify a search string to ignore signatures and filter on files containing this string (regex compatible)")
 	localFlag        = flag.String("local", "", "Specify local directory (absolute path) which to scan. Scans only given directory recursively. No need to have GitHub tokens with local run.")
@@ -243,7 +243,7 @@ func main() {
 		PathChecks:             pathChecksFlag,
 		ProcessGists:           gistsFlag,
 		TempDirectory:          tempDirFlag,
-		CsvPath:                csvFlag,
+		CSVPath:                csvFlag,
 		SearchQuery:            searchQueryFlag,
 		Local:                  localFlag,
 		Live:                   liveFlag,

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -252,7 +253,8 @@ func main() {
 	})
 
 	if err != nil {
-		s.Log.Fatal("new session: %v", err)
+		fmt.Printf("Failed to create session: %v\n", err)
+		os.Exit(1)
 	}
 
 	s.Log.Info(color.HiBlueString(core.Banner))


### PR DESCRIPTION
This PR addresses some embedding issues I experienced with the `core` library:

* Global sessions made it difficult to process multiple repositories simultaneous
* Global flags made it equally difficult to have multiple configurations simultaneously
* Hardcoded `config.yaml` name felt awkward (For instance, I prefer `sshgit.yaml`).

Please let me know if there are any improvements you would like me to make. Thanks for the excellent tool & library!

